### PR TITLE
Make trend reflect the future

### DIFF
--- a/app/src/lib/conviction.js
+++ b/app/src/lib/conviction.js
@@ -177,7 +177,7 @@ export function getRemainingTimeToPass(
 }
 
 /**
- * Gets conviction trend in percentage since last `timeSpan` amount of blocks.
+ * Gets conviction trend in percentage for the next `timeSpan` amount of blocks.
  * @param {{time: number, tokenStaked: number, totalTokensStaked: number}[]}
  * stakes List of token stakes made on a proposal
  * @param {number} maxConviction Max conviction possible with current token supply
@@ -194,10 +194,9 @@ export function getConvictionTrend(
   timeSpan = 5,
   alpha
 ) {
-  const history = getConvictionHistory(stakes, time, alpha)
-  const pastConviction = history[history.length - timeSpan]
   const currentConviction = getCurrentConviction(stakes, time, alpha)
-  return (currentConviction - pastConviction) / maxConviction
+  const futureConviction = getCurrentConviction(stakes, time + timeSpan, alpha)
+  return (futureConviction - currentConviction) / maxConviction
 }
 
 /**


### PR DESCRIPTION
Right now, the trend indicator reflects how conviction has changed on a proposal during the last 5 units of time. Do we want to change it to reflect the prediction on how conviction is going to change in the following 5 units of time? What do have more sense?