### PR TITLE
Update script

### DIFF
--- a/app/src/app-state-reducer.js
+++ b/app/src/app-state-reducer.js
@@ -1,0 +1,27 @@
+import BN from 'bn.js'
+
+export default function reducer(state) {
+  if (state === null) {
+    return {
+      globalParams: {},
+      stakeToken: {},
+      requestToken: {},
+      proposals: [],
+      convictionStakes: [],
+      isSyncing: true,
+    }
+  }
+
+  const { proposals } = state
+  return {
+    ...state,
+
+    proposals: proposals.map(({ stakes, ...proposal }) => ({
+      ...proposal,
+      stakes: stakes.map(({ amount, ...stake }) => ({
+        ...stake,
+        amount: new BN(amount),
+      })),
+    })),
+  }
+}

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -4,20 +4,7 @@ import { AragonApi } from '@aragon/api-react'
 import App from './App'
 import { BlockNumberProvider } from './BlockContext'
 import { IdentityProvider } from './identity-manager'
-
-const reducer = state => {
-  if (state === null) {
-    return {
-      globalParams: {},
-      stakeToken: {},
-      requestToken: {},
-      proposals: [],
-      convictionStakes: [],
-      isSyncing: true,
-    }
-  }
-  return state
-}
+import reducer from './app-state-reducer.js'
 
 ReactDOM.render(
   <AragonApi reducer={reducer}>

--- a/app/src/screens/Proposals.js
+++ b/app/src/screens/Proposals.js
@@ -124,14 +124,14 @@ const Proposals = React.memo(
                 ...statusField,
               ]}
               statusEmpty={
-                <h2
+                <p
                   css={`
                     ${textStyle('title2')};
                     font-weight: 600;
                   `}
                 >
                   No proposals yet!
-                </h2>
+                </p>
               }
               entries={sortedProposals}
               renderEntry={proposal => {

--- a/app/src/script.js
+++ b/app/src/script.js
@@ -123,7 +123,7 @@ async function initialize([
         return onUpdatedAccount(nextState, returnValues, stakeToken.contract)
       case 'ProposalAdded':
         return onNewProposal(nextState, returnValues)
-      case 'StakeChanged':
+      case 'StakeAdded':
         return onStakeUpdated(nextState, returnValues, blockNumber)
       case 'StakeWithdrawn':
         return onStakeUpdated(nextState, returnValues, blockNumber)

--- a/app/src/script.js
+++ b/app/src/script.js
@@ -91,23 +91,12 @@ async function initialize([
   }
 
   async function reducer(state, { event, returnValues, blockNumber, address }) {
-    console.log(event, returnValues)
-    let nextState = { ...state }
+    const nextState = { ...state }
 
     if (addressesEqual(address, stakeTokenAddress)) {
       switch (event) {
         case 'Transfer':
-          const tokenSupply = await stakeToken.contract
-            .totalSupply()
-            .toPromise()
-          nextState = {
-            ...nextState,
-            stakeToken: {
-              ...nextState.stakeToken,
-              tokenSupply,
-            },
-          }
-          return nextState
+          return onNewTransfer(nextState, stakeToken.contract)
         default:
           return nextState
       }
@@ -126,75 +115,23 @@ async function initialize([
     }
 
     switch (event) {
-      case 'ProposalAdded': {
-        const { entity, id, title, amount, beneficiary, link } = returnValues
-        const newProposal = {
-          id: parseInt(id),
-          name: title,
-          link: link && toUtf8(link), // Can be an HTTP or IPFS link
-          requestedAmount: parseInt(amount),
-          creator: entity,
-          beneficiary,
-        }
-        nextState = {
-          ...nextState,
-          proposals: [...nextState.proposals, newProposal],
-        }
-        break
-      }
-      case 'StakeChanged': {
-        const {
-          entity,
-          id,
-          tokensStaked,
-          totalTokensStaked,
-          conviction,
-        } = returnValues
-        nextState.convictionStakes.push({
-          entity,
-          proposal: parseInt(id),
-          tokensStaked: parseInt(tokensStaked),
-          totalTokensStaked: parseInt(totalTokensStaked),
-          time: blockNumber,
-          conviction: parseInt(conviction),
-        })
-        break
-      }
-      case 'ProposalExecuted': {
-        const { id } = returnValues
-        nextState = {
-          ...nextState,
-          proposals: nextState.proposals.map(proposal => {
-            if (proposal.id === parseInt(id)) {
-              return { ...proposal, executed: true }
-            }
-            return proposal
-          }),
-        }
-        break
-      }
       case events.SYNC_STATUS_SYNCING:
-        nextState = { ...nextState, isSyncing: true }
-        break
+        return { ...nextState, isSyncing: true }
       case events.SYNC_STATUS_SYNCED:
-        nextState = { ...nextState, isSyncing: false }
-        break
-      case events.ACCOUNTS_TRIGGER: {
-        const { account } = returnValues
-        nextState = {
-          ...nextState,
-          stakeToken: {
-            ...nextState.stakeToken,
-            balance: account
-              ? await stakeToken.contract.balanceOf(account).toPromise()
-              : 0,
-          },
-        }
-      }
+        return { ...nextState, isSyncing: false }
+      case events.ACCOUNTS_TRIGGER:
+        return onUpdatedAccount(nextState, returnValues, stakeToken.contract)
+      case 'ProposalAdded':
+        return onNewProposal(nextState, returnValues)
+      case 'StakeChanged':
+        return onStakeUpdated(nextState, returnValues, blockNumber)
+      case 'StakeWithdrawn':
+        return onStakeUpdated(nextState, returnValues, blockNumber)
+      case 'ProposalExecuted':
+        return onProposalExecuted(nextState, returnValues)
+      default:
+        return nextState
     }
-
-    console.log(nextState)
-    return nextState
   }
 
   const storeOptions = {
@@ -214,6 +151,12 @@ async function initialize([
 
   return app.store(reducer, storeOptions)
 }
+
+/***********************
+ *                     *
+ *   Event Handlers    *
+ *                     *
+ ***********************/
 
 function initState(stakeToken, vault, requestTokenAddress) {
   return async cachedState => {
@@ -248,6 +191,103 @@ function initState(stakeToken, vault, requestTokenAddress) {
   }
 }
 
+// Conviction Voting events //
+async function onUpdatedAccount(state, { account }, stakeTokenContract) {
+  const accountBalance = account
+    ? await stakeTokenContract.balanceOf(account).toPromise()
+    : 0
+
+  return {
+    ...state,
+    stakeToken: {
+      ...state.stakeToken,
+      balance: accountBalance,
+    },
+  }
+}
+
+function onNewProposal(state, returnValues) {
+  const { entity, id, title, amount, beneficiary, link } = returnValues
+
+  const newProposal = {
+    id: parseInt(id),
+    name: title,
+    link: link && toUtf8(link), // Can be an HTTP or IPFS link
+    requestedAmount: parseInt(amount),
+    creator: entity,
+    beneficiary,
+    stakes: [],
+  }
+  return {
+    ...state,
+    proposals: [...state.proposals, newProposal],
+  }
+}
+
+function onStakeUpdated(
+  { proposals, convictionStakes, ...state },
+  returnValues,
+  blockNumber
+) {
+  const { entity, id, tokensStaked } = returnValues
+
+  const updatedProposals = proposals.map(proposal => {
+    if (proposal.id === parseInt(id)) {
+      const updatedStakes = updateProposalStakes(
+        proposal.stakes,
+        entity,
+        tokensStaked
+      )
+      return { ...proposal, stakes: updatedStakes }
+    }
+
+    return proposal
+  })
+
+  const updatedConvictionStakes = updateConvictionStakes(
+    convictionStakes,
+    returnValues,
+    blockNumber
+  )
+
+  return {
+    ...state,
+    convictionStakes: updatedConvictionStakes,
+    proposals: updatedProposals,
+  }
+}
+
+function onProposalExecuted(state, { id }) {
+  return {
+    ...state,
+    proposals: state.proposals.map(proposal => {
+      if (proposal.id === parseInt(id)) {
+        return { ...proposal, executed: true }
+      }
+      return proposal
+    }),
+  }
+}
+
+// Stake token events //
+async function onNewTransfer(state, stakeTokenContract) {
+  const tokenSupply = await stakeTokenContract.totalSupply().toPromise()
+
+  return {
+    ...state,
+    stakeToken: {
+      ...state.stakeToken,
+      tokenSupply,
+    },
+  }
+}
+
+/***********************
+ *                     *
+ *       Helpers       *
+ *                     *
+ ***********************/
+
 async function getRequestTokenSettings(address, vault) {
   return (
     { ...(await updateBalances([], address, app, vault))[0], address } || {}
@@ -266,4 +306,37 @@ async function loadGlobalParams() {
     maxRatio: parseInt(maxRatio) / D,
     weight: parseInt(weight) / D,
   }
+}
+
+function updateProposalStakes(stakes, entity, newTokensStaked) {
+  const index = stakes.findIndex(stake => addressesEqual(stake.entity, entity))
+
+  if (index === -1) {
+    return [...stakes, { entity, amount: newTokensStaked }]
+  }
+
+  const updatedStake = { ...stakes[index], amount: newTokensStaked }
+
+  return [...stakes.slice(0, index), updatedStake, ...stakes.slice(index + 1)]
+}
+
+function updateConvictionStakes(convictionStakes, returnValues, blockNumber) {
+  const {
+    entity,
+    id,
+    tokensStaked,
+    totalTokensStaked,
+    conviction,
+  } = returnValues
+
+  const newStake = {
+    entity,
+    proposal: parseInt(id),
+    tokensStaked: parseInt(tokensStaked),
+    totalTokensStaked: parseInt(totalTokensStaked),
+    time: blockNumber,
+    conviction: parseInt(conviction),
+  }
+
+  return [...convictionStakes, newStake]
 }

--- a/contracts/ConvictionVoting.sol
+++ b/contracts/ConvictionVoting.sol
@@ -15,7 +15,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
 
     // Events
     event ProposalAdded(address entity, uint256 id, string title, bytes link, uint256 amount, address beneficiary);
-    event StakeChanged(address entity, uint256 id, uint256  amount, uint256 tokensStaked, uint256 totalTokensStaked, uint256 conviction);
+    event StakeAdded(address entity, uint256 id, uint256  amount, uint256 tokensStaked, uint256 totalTokensStaked, uint256 conviction);
     event StakeWithdrawn(address entity, uint256 id, uint256 amount, uint256 tokensStaked, uint256 totalTokensStaked, uint256 conviction);
     event ProposalExecuted(uint256 id, uint256 conviction);
 
@@ -348,7 +348,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
             proposal.blockLast = getBlockNumber64();
         }
         _calculateAndSetConviction(_id, oldStaked);
-        emit StakeChanged(_from, _id, _amount, proposal.stakesPerVoter[_from], proposal.stakedTokens, proposal.convictionLast);
+        emit StakeAdded(_from, _id, _amount, proposal.stakesPerVoter[_from], proposal.stakedTokens, proposal.convictionLast);
     }
 
     /**

--- a/contracts/ConvictionVoting.sol
+++ b/contracts/ConvictionVoting.sol
@@ -15,7 +15,8 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
 
     // Events
     event ProposalAdded(address entity, uint256 id, string title, bytes link, uint256 amount, address beneficiary);
-    event StakeChanged(address entity, uint256 id, uint256 tokensStaked, uint256 totalTokensStaked, uint256 conviction);
+    event StakeChanged(address entity, uint256 id, uint256  amount, uint256 tokensStaked, uint256 totalTokensStaked, uint256 conviction);
+    event StakeWithdrawn(address entity, uint256 id, uint256 amount, uint256 tokensStaked, uint256 totalTokensStaked, uint256 conviction);
     event ProposalExecuted(uint256 id, uint256 conviction);
 
     // Constants
@@ -120,7 +121,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
     }
 
     /**
-      * @notice Stake `@tokenAmount((self.stakeToken(): address), amount)` on proposal #`id`
+      * @notice Stake `@tokenAmount((self.stakeToken(): address), _amount)` on proposal #`_id`
       * @param _id Proposal id
       * @param _amount Amount of tokens staked
       */
@@ -129,7 +130,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
     }
 
     /**
-     * @notice Stake all my `(self.stakeToken(): address).symbol(): string` tokens on proposal #`id`
+     * @notice Stake all my `(self.stakeToken(): address).symbol(): string` tokens on proposal #`_id`
      * @param _id Proposal id
      */
     function stakeAllToProposal(uint256 _id) external isInitialized() {
@@ -138,7 +139,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
     }
 
     /**
-     * @notice Withdraw `@tokenAmount((self.stakeToken(): address), amount)` previously staked on proposal #`id`
+     * @notice Withdraw `@tokenAmount((self.stakeToken(): address), _amount)` previously staked on proposal #`_id`
      * @param _id Proposal id
      * @param _amount Amount of tokens withdrawn
      */
@@ -147,7 +148,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
     }
 
     /**
-     * @notice Withdraw all `(self.stakeToken(): address).symbol(): string` tokens previously staked on proposal #`id`
+     * @notice Withdraw all `(self.stakeToken(): address).symbol(): string` tokens previously staked on proposal #`_id`
      * @param _id Proposal id
      */
     function withdrawAllFromProposal(uint256 _id) external isInitialized() {
@@ -155,7 +156,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
     }
 
     /**
-     * @notice Execute proposal #`id`
+     * @notice Execute proposal #`_id`
      * @dev ...by sending `@tokenAmount((self.requestToken(): address), self.getPropoal(id): ([uint256], address, uint256, uint256, uint64, bool))` to `self.getPropoal(id): (uint256, [address], uint256, uint256, uint64, bool)`
      * @param _id Proposal id
      * @param _withdrawIfPossible True if sender's staked tokens should be withdrawed after execution
@@ -204,7 +205,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
     }
 
     /**
-     * @notice Get stake of voter `voter` on proposal #`id`
+     * @notice Get stake of voter `_voter` on proposal #`_id`
      * @param _id Proposal id
      * @param _voter Entity address that previously might voted on that proposal
      * @return Current amount of staked tokens by voter on proposal
@@ -214,7 +215,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
     }
 
     /**
-     * @notice Get total stake of voter `voter` on proposals
+     * @notice Get total stake of voter `_voter` on proposals
      * @param _voter Entity address that previously might voted on that proposal
      * @return Current amount of staked tokens by voter on proposal
      */
@@ -347,7 +348,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
             proposal.blockLast = getBlockNumber64();
         }
         _calculateAndSetConviction(_id, oldStaked);
-        emit StakeChanged(_from, _id, proposal.stakesPerVoter[_from], proposal.stakedTokens, proposal.convictionLast);
+        emit StakeChanged(_from, _id, _amount, proposal.stakesPerVoter[_from], proposal.stakedTokens, proposal.convictionLast);
     }
 
     /**
@@ -401,7 +402,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
         if (!proposal.executed) {
             _calculateAndSetConviction(_id, oldStaked);
         }
-        emit StakeChanged(_from, _id, proposal.stakesPerVoter[_from], proposal.stakedTokens, proposal.convictionLast);
+        emit StakeWithdrawn(_from, _id, _amount, proposal.stakesPerVoter[_from], proposal.stakedTokens, proposal.convictionLast);
     }
 
     /**


### PR DESCRIPTION
PR for updating background script

- Moved every event handler to its own function
- We now save current stakes per proposal into the proposal object itself
- Fixed some docs strings and splitted stake and withdraw events

We were discussing with @rperez89 if maybe we should rename `convictionStakes` variable into  `stakesHistory` or something like that so it's clear.

Regarding splitted events (`StakeChanged` and `stakeWithdrawn`), note that we are using the same function handler but i think it makes more sense to have them differentiated for potential features that could need it.

