### PR TITLE
Fix issue with not withdrawing from cancelled proposals. Add tests.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ build
 .cache
 dist
 coverage
+test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ipfs.cmd
 package-lock.json
 coverage.json
 coverage
+.idea

--- a/contracts/ConvictionVoting.sol
+++ b/contracts/ConvictionVoting.sol
@@ -564,7 +564,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
             voterStakedProposals[_from].deleteItem(_proposalId);
         }
 
-        if (proposal.proposalStatus != ProposalStatus.Executed) {
+        if (proposal.proposalStatus == ProposalStatus.Active) {
             _calculateAndSetConviction(proposal, previousStake);
         }
 

--- a/contracts/ConvictionVoting.sol
+++ b/contracts/ConvictionVoting.sol
@@ -496,7 +496,7 @@ contract ConvictionVoting is AragonApp, TokenManagerHook {
             uint256 proposalId = voterStakedProposalsCopy[i];
             Proposal storage proposal = proposals[proposalId];
 
-            if (proposal.proposalStatus == ProposalStatus.Executed) {
+            if (proposal.proposalStatus == ProposalStatus.Executed || proposal.proposalStatus == ProposalStatus.Cancelled) {
                 toWithdraw = proposal.voterStake[_from];
                 if (toWithdraw > 0) {
                     _withdrawFromProposal(proposalId, toWithdraw, _from);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "prettier": "^1.18.2",
     "solidity-coverage": "^0.6.2",
     "truffle": "5.1.4",
-    "wait-on": "^4.0.1"
+    "wait-on": "^4.0.1",
+    "chai": "^4.2.0"
   },
   "scripts": {
     "prepare": "cd app && npm install && cd ..",
@@ -53,7 +54,8 @@
     "lint": "eslint . & solium --dir ./contracts",
     "lint:fix": "eslint . --fix & solium --dir ./contracts --fix",
     "compile": "truffle compile",
-    "test": "cross-env TRUFFLE_TEST=true npm run ganache-cli:test",
+    "test:old": "cross-env TRUFFLE_TEST=true npm run ganache-cli:test",
+    "test": "TRUFFLE_TEST=true truffle test --network rpc",
     "coverage": "cross-env SOLIDITY_COVERAGE=true npm run ganache-cli:test",
     "ganache-cli:test": "sh ./node_modules/@aragon/test-helpers/ganache-cli.sh",
     "publish:patch": "aragon apm publish patch",

--- a/test/conviction-voting.js
+++ b/test/conviction-voting.js
@@ -1,5 +1,3 @@
-/* global artifacts contract before beforeEach context it assert web3 */
-
 const { getEventArgument } = require('@aragon/contract-helpers-test/src/events')
 const { assertRevert } = require('@aragon/contract-helpers-test/src/asserts')
 const deployDAO = require('./helpers/deployDAO')
@@ -14,7 +12,6 @@ const BN = web3.utils.toBN
 const ONE_HUNDRED_PERCENT = 1e18
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 const ANY_ADDRESS = '0xffffffffffffffffffffffffffffffffffffffff'
-const ONE_DAY = 60 * 60 * 24
 const D = 10 ** 7
 const DEFAULT_ALPHA = 0.9 * D
 const DEFAULT_BETA = 0.2 * D
@@ -274,6 +271,20 @@ contract('ConvictionVoting', ([appManager, user, beneficiary]) => {
             DEFAULT_APP_MANAGER_STAKE_TOKENS, DEFAULT_APP_MANAGER_STAKE_TOKENS, [proposal2Id], DEFAULT_APP_MANAGER_STAKE_TOKENS)
         })
 
+        it('should reassign previously staked tokens after previous vote cancelled', async () => {
+          await convictionVoting.stakeToProposal(proposalId, DEFAULT_APP_MANAGER_STAKE_TOKENS)
+          await convictionVoting.cancelProposal(proposalId)
+          const addProposalReceipt = await convictionVoting.addProposal('Proposal 2', '0x', requestedAmount, beneficiary)
+          const proposal2Id = getEventArgument(addProposalReceipt, 'ProposalAdded', 'id')
+          const currentBlock = await convictionVoting.getBlockNumberPublic()
+
+          await convictionVoting.stakeToProposal(proposal2Id, DEFAULT_APP_MANAGER_STAKE_TOKENS)
+
+          await assertProposalAndStakesCorrect(
+              proposal2Id, 0, DEFAULT_APP_MANAGER_STAKE_TOKENS, currentBlock.toNumber() + 1,
+              DEFAULT_APP_MANAGER_STAKE_TOKENS, DEFAULT_APP_MANAGER_STAKE_TOKENS, [proposal2Id], DEFAULT_APP_MANAGER_STAKE_TOKENS)
+        })
+
         const createAndExecuteProposals = async (numberOfProposals, stakeForProposals) => {
           let newProposalIds = []
           for (let i = 0; i < numberOfProposals; i++) {
@@ -315,6 +326,63 @@ contract('ConvictionVoting', ([appManager, user, beneficiary]) => {
             proposalId, 0, DEFAULT_APP_MANAGER_STAKE_TOKENS, currentBlock,
             DEFAULT_APP_MANAGER_STAKE_TOKENS, DEFAULT_APP_MANAGER_STAKE_TOKENS, [proposalId], DEFAULT_APP_MANAGER_STAKE_TOKENS)
         })
+
+        const createAndCancelProposals = async (numberOfProposals, stakeForProposals) => {
+          let newProposalIds = []
+          for (let i = 0; i < numberOfProposals; i++) {
+            const addNewProposalReceipt = await convictionVoting.addProposal('Proposal', '0x', 100, beneficiary)
+            const newProposalId = getEventArgument(addNewProposalReceipt, 'ProposalAdded', 'id')
+            await convictionVoting.stakeToProposal(newProposalId, stakeForProposals)
+            newProposalIds.push(newProposalId.toNumber())
+          }
+
+          for (const newProposalId of newProposalIds) {
+            await convictionVoting.cancelProposal(newProposalId)
+          }
+        }
+
+        it('should reassign previously staked tokens after 2 previous votes cancelled', async () => {
+          await createAndCancelProposals(2, DEFAULT_APP_MANAGER_STAKE_TOKENS / 2)
+          const addProposalReceipt = await convictionVoting.addProposal('Proposal', '0x', requestedAmount, beneficiary)
+          const proposalId = getEventArgument(addProposalReceipt, 'ProposalAdded', 'id')
+          const currentBlock = await convictionVoting.getBlockNumberPublic()
+
+          await convictionVoting.stakeToProposal(proposalId, DEFAULT_APP_MANAGER_STAKE_TOKENS)
+
+          await assertProposalAndStakesCorrect(
+              proposalId, 0, DEFAULT_APP_MANAGER_STAKE_TOKENS, currentBlock.toNumber() + 1,
+              DEFAULT_APP_MANAGER_STAKE_TOKENS, DEFAULT_APP_MANAGER_STAKE_TOKENS, [proposalId], DEFAULT_APP_MANAGER_STAKE_TOKENS)
+        })
+
+        it('should reassign previously staked tokens after many previous votes cancelled', async () => {
+          await createAndCancelProposals(8, DEFAULT_APP_MANAGER_STAKE_TOKENS / 8)
+          const addProposalReceipt = await convictionVoting.addProposal('Proposal', '0x', requestedAmount, beneficiary)
+          const proposalId = getEventArgument(addProposalReceipt, 'ProposalAdded', 'id')
+          const currentBlock = await convictionVoting.getBlockNumberPublic()
+
+          await convictionVoting.stakeToProposal(proposalId, DEFAULT_APP_MANAGER_STAKE_TOKENS)
+
+          await assertProposalAndStakesCorrect(
+              proposalId, 0, DEFAULT_APP_MANAGER_STAKE_TOKENS, currentBlock.toNumber() + 1,
+              DEFAULT_APP_MANAGER_STAKE_TOKENS, DEFAULT_APP_MANAGER_STAKE_TOKENS, [proposalId], DEFAULT_APP_MANAGER_STAKE_TOKENS)
+        })
+
+        it('should reassign previously staked tokens after many previous votes cancelled and executed', async () => {
+          const cancelledProposalsTotalStake = DEFAULT_APP_MANAGER_STAKE_TOKENS / 3
+          const executedProposalsTotalStake = DEFAULT_APP_MANAGER_STAKE_TOKENS - cancelledProposalsTotalStake
+          await createAndCancelProposals(2, cancelledProposalsTotalStake / 2)
+          await createAndExecuteProposals(4, executedProposalsTotalStake / 4)
+          const addProposalReceipt = await convictionVoting.addProposal('Proposal', '0x', requestedAmount, beneficiary)
+          const proposalId = getEventArgument(addProposalReceipt, 'ProposalAdded', 'id')
+          const currentBlock = await convictionVoting.getBlockNumberPublic()
+
+          await convictionVoting.stakeToProposal(proposalId, DEFAULT_APP_MANAGER_STAKE_TOKENS)
+
+          await assertProposalAndStakesCorrect(
+              proposalId, 0, DEFAULT_APP_MANAGER_STAKE_TOKENS, currentBlock,
+              DEFAULT_APP_MANAGER_STAKE_TOKENS, DEFAULT_APP_MANAGER_STAKE_TOKENS, [proposalId], DEFAULT_APP_MANAGER_STAKE_TOKENS)
+        })
+
 
         it('should not reassign previously staked tokens before previous vote execution', async () => {
           await convictionVoting.stakeToProposal(proposalId, DEFAULT_APP_MANAGER_STAKE_TOKENS)
@@ -527,7 +595,7 @@ contract('ConvictionVoting', ([appManager, user, beneficiary]) => {
             assert.equal(proposal3AppManagerStake.toString(), DEFAULT_APP_MANAGER_STAKE_TOKENS / numberOfProposals, 'Incorrect proposal 3 voter stake')
           })
 
-          it('unstakes staked tokens when transferring more than currently unstaked from many open and closed proposals', async () => {
+          it('unstakes staked tokens when transferring more than currently unstaked from many open and executed proposals', async () => {
             const numberOfProposals = 4
             const transferAmount = (DEFAULT_APP_MANAGER_STAKE_TOKENS / 2) + 1000
             const totalAppManagerStake = DEFAULT_APP_MANAGER_STAKE_TOKENS - transferAmount
@@ -541,6 +609,28 @@ contract('ConvictionVoting', ([appManager, user, beneficiary]) => {
             await assertProposalAndStakesCorrect(
               newProposalIds[0], 74470, 0, currentBlock.toNumber(),
               0, totalAppManagerStake, [newProposalIds[1], newProposalIds[2]], totalAppManagerStake)
+            const proposal1AppManagerStake = await convictionVoting.getProposalVoterStake(newProposalIds[1], appManager)
+            assert.equal(proposal1AppManagerStake.toString(), DEFAULT_APP_MANAGER_STAKE_TOKENS / numberOfProposals - 1000, 'Incorrect proposal 1 voter stake')
+            const proposal2AppManagerStake = await convictionVoting.getProposalVoterStake(newProposalIds[2], appManager)
+            assert.equal(proposal2AppManagerStake.toString(), DEFAULT_APP_MANAGER_STAKE_TOKENS / numberOfProposals, 'Incorrect proposal 2 voter stake')
+            const proposal3AppManagerStake = await convictionVoting.getProposalVoterStake(newProposalIds[3], appManager)
+            assert.equal(proposal3AppManagerStake.toString(), 0, 'Incorrect proposal 3 voter stake')
+          })
+
+          it('unstakes staked tokens when transferring more than currently unstaked from many open and cancelled proposals', async () => {
+            const numberOfProposals = 4
+            const transferAmount = (DEFAULT_APP_MANAGER_STAKE_TOKENS / 2) + 1000
+            const totalAppManagerStake = DEFAULT_APP_MANAGER_STAKE_TOKENS - transferAmount
+            const newProposalIds = await createAndStakeToProposals(numberOfProposals, DEFAULT_APP_MANAGER_STAKE_TOKENS / numberOfProposals)
+            await convictionVoting.mockAdvanceBlocks(40)
+            await convictionVoting.cancelProposal(newProposalIds[3])
+            const currentBlock = await convictionVoting.getBlockNumberPublic()
+
+            await stakeToken.transfer(user, transferAmount)
+
+            await assertProposalAndStakesCorrect(
+                newProposalIds[0], 74470, 0, currentBlock.toNumber(),
+                0, totalAppManagerStake, [newProposalIds[1], newProposalIds[2]], totalAppManagerStake)
             const proposal1AppManagerStake = await convictionVoting.getProposalVoterStake(newProposalIds[1], appManager)
             assert.equal(proposal1AppManagerStake.toString(), DEFAULT_APP_MANAGER_STAKE_TOKENS / numberOfProposals - 1000, 'Incorrect proposal 1 voter stake')
             const proposal2AppManagerStake = await convictionVoting.getProposalVoterStake(newProposalIds[2], appManager)
@@ -690,7 +780,6 @@ contract('ConvictionVoting', ([appManager, user, beneficiary]) => {
         })
 
         it('should revert when sender does not have permission and is not the proposal submitter', async () => {
-          const cancelProposalRole = await convictionVoting.CANCEL_PROPOSAL_ROLE()
           await assertRevert(convictionVoting.cancelProposal(proposalId, { from: user }), 'CV_SENDER_CANNOT_CANCEL')
         })
 


### PR DESCRIPTION
Will now withdraw from cancelled proposals as well as executed ones when staking to a new proposal and not having already un-staked, or transferring the stake token.

Fixes issue #108 